### PR TITLE
Readme Horizontal Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ For sound check out the [video](https://youtu.be/xRLMbQ5TKVU)
 * Build for iPad with external Keyboard attached.
 * Multi language support, based on active keyboard language
 
---
+---
 
 An idea inspired by https://twitter.com/crowbarska/status/1255898834510716932


### PR DESCRIPTION
There was a "-" missing in the Markdown-Code to display it as a horizontal line.

Please authorize my first ever pull request ☺.